### PR TITLE
mark automatic followups as resolved

### DIFF
--- a/src/piazza/APiazzaClass.java
+++ b/src/piazza/APiazzaClass.java
@@ -138,6 +138,17 @@ public class APiazzaClass implements PiazzaClass {
 		JSONObject data = new JSONObject().put("cid", cid).put("subject", post)
 				.put("type", "followup").put("content", "").put("anonymous", "no");
 		Map<String, Object> resp = this.mySession.piazzaAPICall("content.create", data, piazzaLogic);
+                if (resp == null) return false;
+                // mark resolved {{{
+                String followupID = resp.get("id").toString();
+                data = new JSONObject()
+                  .put("cid", followupID)
+                  .put("resolved", "true");
+                resp = mySession.piazzaAPICall(
+                    "content.mark_resolved",
+                    data,
+                    piazzaLogic);
+                // }}}
 //		System.out.println(resp.toString());
 		return resp != null? true:false;
 	}

--- a/src/piazza/APiazzaClass.java
+++ b/src/piazza/APiazzaClass.java
@@ -140,7 +140,8 @@ public class APiazzaClass implements PiazzaClass {
 		Map<String, Object> resp = this.mySession.piazzaAPICall("content.create", data, piazzaLogic);
                 if (resp == null) return false;
                 // mark resolved {{{
-                String followupID = resp.get("id").toString();
+                Map<String, Object> res = (Map<String, Object>) resp.get("result");
+                String followupID = res.get("id").toString();
                 data = new JSONObject()
                   .put("cid", followupID)
                   .put("resolved", "true");


### PR DESCRIPTION
Let's not merge this until I test it on the next grading period.

The idea is to grab the ID returned in creating the post, and then use that in another API call to mark it as resolved.

I took heavy inspiration from [this RPC client](https://github.com/hfaran/piazza-api/blob/164d74cdb83f41d2204da4b051f106dfb59cbd1c/piazza_api/rpc.py#L162) and [its usage in an API client](https://github.com/hfaran/piazza-api/blob/164d74cdb83f41d2204da4b051f106dfb59cbd1c/piazza_api/network.py#L298)

I did test this privately in python, as you can see in this python transcript:

```python
>>> from piazza_api.rpc import PiazzaRPC as P
>>> P
<class 'piazza_api.rpc.PiazzaRPC'>
>>> p = P('kdoiylw2pgb38l')
>>> p.user_login()                                                                                                                                                                                
Email: SCRUBBED
Password:
>>> followup = {
... 'cid': 152,
... 'type': 'followup',
... 'subject': 'this is my test followup',
... 'content': '',
... 'anonymous': 'no',
... }
>>> p.content_get(152)
{'folders': ['other'], 'nr': 152, 'data': {'embed_links': []}, 'created': '2020-09-01T21:13:33Z', 'bucket_order': 3, 'no_answer_followup': 0, 'change_log': [{'anon': 'no', 'uid': 'is7jowjzfwoh1', 'data': 'kekg86qa17es8', 'v': 'private', 'type': 'create', 'when': '2020-09-01T21:13:33Z'}], 'bucket_name': 'Today', 'history': [{'anon': 'no', 'uid': 'is7jowjzfwoh1', 'subject': 'This is a test', 'created': '2020-09-01T21:13:33Z', 'content': 'Ignore this Andrew; I&#39;m using it to test some thing in the diary grader right quick.'}], 'type': 'note', 'anon_map': {}, 'tags': ['instructor-note', 'other'], 'tag_good': [], 'unique_views': 1, 'children': [], 'tag_good_arr': [], 'anon_icons': True, 'id': 'kekg86q8ous7', 'config': {'feed_groups': 'j6p1kuysq514z0,is7jowjzfwoh1'}, 'status': 'private', 'request_instructor': 0, 'request_instructor_me': False, 'bookmarked': 1, 'num_favorites': 0, 'my_favorite': False, 'is_bookmarked': True, 'is_tag_good': False, 'q_edits': [], 'i_edits': [], 's_edits': [], 't': 1598995172627, 'default_anonymity': 'no', 'my_post': True}
>>> p.content_get(152)['id']                                                                                                                                                                      
'kekg86q8ous7'
>>> followup['cid'] = p.content_get(152)['id']
>>> followup
{'cid': 'kekg86q8ous7', 'type': 'followup', 'subject': 'this is my test followup', 'content': '', 'anonymous': 'no'}
>>> resp = p.content_create(followup)                                                                                                                                                                    
>>> resp
{'anon': 'no', 'folders': [], 'data': None, 'no_upvotes': 0, 'subject': 'this is my test followup', 'created': '2020-09-01T21:22:16Z', 'bucket_order': 3, 'bucket_name': 'Today', 'type': 'followup', 'tag_good': [], 'uid': 'is7jowjzfwoh1', 'children': [], 'tag_good_arr': [], 'no_answer': 1, 'id': 'kekgjdphgs31bl', 'updated': '2020-09-01T21:22:16Z', 'config': {}}
>>> fid = resp['id']
>>> fid
'kekgjdphgs31bl'
>>> p.request(method='content.mark_resolved', data=dict(cid=fid, resolved='true'))                                                                                                                
{'result': {'anon': 'no', 'folders': [], 'data': None, 'no_upvotes': 0, 'subject': 'this is my test followup', 'created': '2020-09-01T21:22:16Z', 'bucket_order': 3, 'bucket_name': 'Today', 'type': 'followup', 'tag_good': [], 'uid': 'is7jowjzfwoh1', 'children': [], 'tag_good_arr': [], 'no_answer': 0, 'id': 'kekgjdphgs31bl', 'updated': '2020-09-01T21:22:16Z', 'config': {}}, 'error': None, 'aid': 'kekgmjdctdv6'}
```